### PR TITLE
Missing Underscore

### DIFF
--- a/wp-content/themes/arising/sass/style.scss
+++ b/wp-content/themes/arising/sass/style.scss
@@ -15,4 +15,4 @@
 @import "_partials/variables";
 @import "_partials/wordpress-core";
 
-@import "layout/gridz";
+@import "_layout/gridz";


### PR DESCRIPTION
- There was a missing underscore before the folder name when calling gridz causing styles to break